### PR TITLE
jsdom update

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "jsdom": "3.1.2"
+    "jsdom": "^6.5.1"
   },
   "devDependencies": {
     "babel": "5.8.23",

--- a/src/jsdomify.js
+++ b/src/jsdomify.js
@@ -7,7 +7,7 @@ let create = (domString) => {
 
   actualDOM = domString || '';
   global.document = jsdom(actualDOM);
-  global.window = document.parentWindow;
+  global.window = document.defaultView;
   global.location = window.location;
   global.Element = window.Element;
   global.navigator = {


### PR DESCRIPTION
Some time ago I tried to make mocha work with react and build this [mocha-react-boilerplate](https://github.com/peerigon/mocha-react-boilerplate). 
However, I met @Munter at the JSConfEu and he showed me jsdomify. So I wanted to use it on our recent project, but it does not work with node 4.x. 
I haven't made any deep investigation about breaking changes between jsdom 3 and jsdom 6, but the tests pass and maybe this pull request makes jsdomify work with node 4.

Changes:
- updates jsdom 6
- fixes reference to "document.window"
