### PR TITLE
Set the global XMLHttpRequest to the window XMLHttpRequest

### DIFF
--- a/src/jsdomify.js
+++ b/src/jsdomify.js
@@ -35,6 +35,7 @@ let destroy = (clearRequireCache) => {
   delete global.Element;
   delete global.navigator;
   delete global.document;
+  delete global.XMLHttpRequest;
   documentRef = undefined;
 
   if (clearRequireCache) {

--- a/src/jsdomify.js
+++ b/src/jsdomify.js
@@ -10,6 +10,7 @@ let create = (domString) => {
   global.window = document.defaultView;
   global.location = window.location;
   global.Element = window.Element;
+  global.XMLHttpRequest = window.XMLHttpRequest;
   global.navigator = {
     userAgent: 'node.js'
   };

--- a/test/test.js
+++ b/test/test.js
@@ -66,11 +66,16 @@ describe('jsdomify API', () => {
       expect(jsdomify.getDocument, 'to throw');
     });
 
-    it('should set the global XMLHttpRequest using the windows XMLHttpRequest', () => {
+    it('should set the global XMLHttpRequest using the windows XMLHttpRequest in create', () => {
       jsdomify.create();
       expect(global.XMLHttpRequest, 'to equal', window.XMLHttpRequest);
     });
 
+    it('should remove the global XMLHttpRequest in destroy', () => {
+      jsdomify.create();
+      jsdomify.destroy();
+      expect(global.XMLHttpRequest, 'to be undefined');
+    });
   });
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -66,6 +66,11 @@ describe('jsdomify API', () => {
       expect(jsdomify.getDocument, 'to throw');
     });
 
+    it('should set the global XMLHttpRequest using the windows XMLHttpRequest', () => {
+      jsdomify.create();
+      expect(global.XMLHttpRequest, 'to equal', window.XMLHttpRequest);
+    });
+
   });
 
 


### PR DESCRIPTION
This was required in order to simply integrate with jQuery ajax requests. With this in place they work out of the box with no extra tinkering.
